### PR TITLE
Cleanly handle unknown license entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --recursive",
+    "coverage-html": "nyc report --reporter=html; open coverage/index.html",
     "report-coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "bin": {
@@ -36,11 +37,13 @@
     "treeify": "^1.1.0"
   },
   "devDependencies": {
+    "ansi-escapes": "^3.1.0",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^13.1.0",
-    "rewire": "^4.0.1"
+    "rewire": "^4.0.1",
+    "strip-ansi": "^5.0.0"
   }
 }

--- a/src/checker.js
+++ b/src/checker.js
@@ -191,21 +191,20 @@ module.exports.summary = async (filePath) => {
 }
 
 module.exports.prettySummary = (summary) => {
-  let approvedTree = _.isEmpty(summary.approved) ? '  None' : treeify.asTree(summary.approved, true)
-  let unApprovedTree = _.isEmpty(summary.unapproved) ? '  None' : treeify.asTree(summary.unapproved, true)
-  let unprocessedTree = _.isEmpty(summary.unprocessedLicenseEntries) ? '  None' : treeify.asTree(summary.unprocessedLicenseEntries, true)
+  let approvedTree = _.isEmpty(summary.approved) ? '  None\n' : treeify.asTree(summary.approved, true)
+  let unApprovedTree = _.isEmpty(summary.unapproved) ? '  None\n' : treeify.asTree(summary.unapproved, true)
+  let unprocessedTree = _.isEmpty(summary.unprocessedLicenseEntries) ? '  None\n' : treeify.asTree(summary.unprocessedLicenseEntries, true)
 
   let prettySummary = [
     `Licenses`,
     '',
     '',
-    'APPROVED',
+    'APPROVED:',
     approvedTree,
-    'UNAPPROVED',
+    'UNAPPROVED:',
     unApprovedTree,
-    'UNPROCESSED',
+    'UNPROCESSED:',
     unprocessedTree,
-    '',
   ].join('\n')
 
   return prettySummary
@@ -215,7 +214,7 @@ module.exports.prettySummary = (summary) => {
  * Get an object of total count of licenses
  * Example:
  * {
- *   licenseMap: {
+ *   licenses: {
  *     'GPL-2.0': 23
  *   },
  *   unprocessedLicenseEntries: {

--- a/src/checker.js
+++ b/src/checker.js
@@ -90,7 +90,6 @@ module.exports.getDependencies = async (opts = {}) => {
 
 // Updates existing licenses based on user input and existing dependencies
 module.exports.getUserLicenseInput = async (existingLicenses) => {
-  // TODO: clean up
   let {
     licenses: licenseMap
   } = await this.generateLicensesMap()
@@ -198,7 +197,6 @@ module.exports.prettySummary = (summary) => {
   let prettySummary = [
     `Licenses`,
     '',
-    '',
     'APPROVED:',
     approvedTree,
     'UNAPPROVED:',
@@ -212,7 +210,8 @@ module.exports.prettySummary = (summary) => {
 
 /**
  * Get an object of total count of licenses
- * Example:
+ *
+ * Example return
  * {
  *   licenses: {
  *     'GPL-2.0': 23

--- a/test/checker.spec.js
+++ b/test/checker.spec.js
@@ -153,32 +153,6 @@ describe('#getDependencies', () => {
   })
 })
 
-describe('#getUserLicenseInput', () => {
-  it('should request and return approved licenses', async () => {
-    const checker = rewire('../src/checker.js')
-    checker.__set__('generateLicensesMap', async () => {
-      return {
-        'Custom': 1, // false
-        'MIT': 100, // not called
-        'Apache 2.0': 100, // true
-        'GPL 1.0': 1, // save and quit
-      }
-    })
-    let answers = ['N', 'Y', 'Save and Quit']
-    checker.__set__('inquirer', {
-      prompt: async () => {
-        return {
-          answerKey: answers.shift()
-        }
-      }
-    })
-    const existingLicenses = ['MIT']
-
-    const result = await checker.getUserLicenseInput(existingLicenses)
-    expect(result).to.eql(['MIT', 'Apache 2.0'])
-  })
-})
-
 describe('#getUserModulesInput', () => {
   it('should request and return approved modules', async () => {
     const checker = rewire('../src/checker.js')

--- a/test/integ/cli.spec.js
+++ b/test/integ/cli.spec.js
@@ -126,6 +126,7 @@ describe('integration test: validates current repo is in a valid state', () => {
     const expectedResult = [
       `Licenses`,
       '',
+      '',
       'APPROVED:',
       '├─ ISC: 21',
       '├─ MIT: 58',
@@ -136,6 +137,9 @@ describe('integration test: validates current repo is in a valid state', () => {
       '└─ CC0-1.0: 1',
       '',
       'UNAPPROVED:',
+      '  None',
+      '',
+      'UNPROCESSED:',
       '  None',
       '',
       '',

--- a/test/integ/cli.spec.js
+++ b/test/integ/cli.spec.js
@@ -126,7 +126,6 @@ describe('integration test: validates current repo is in a valid state', () => {
     const expectedResult = [
       `Licenses`,
       '',
-      '',
       'APPROVED:',
       '├─ ISC: 21',
       '├─ MIT: 58',

--- a/test/integ/cli.spec.js
+++ b/test/integ/cli.spec.js
@@ -10,16 +10,6 @@ const CONFIG_FILENAME = '.approved-licenses.yml'
 const strip = require('strip-ansi')
 const escapes = require('ansi-escapes')
 
-// 
-// Helper functions and data to simulate user CLI interaction.
-// 
-const inputKey = {
-  up: "\\027[A",
-  down: "\\027[B",
-  left: "\\027[D",
-  right: "\\027[C",
-}
-
 // This should not only be the current config checked into git, but also
 // an example of valid config file.
 const expectedCurrentConfigFile = [


### PR DESCRIPTION
Fixing #1 by considering `license` fields with non-string values as "cannot be processed". User will have to approve such modules by module and not by license.