### PR TITLE
feat: non-production dependency checking

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -48,12 +48,13 @@ export function isLicenseValidByConfig(configLicenses, license): boolean {
  *   }
  * }
  */
-export async function generateLicensesMap() {
-  const opts = {
-    start: "./",
-    production: true,
+export async function generateLicensesMap(opts: any = {}) {
+  opts = {
+    ...defaultLicenseInitOpts,
+    ...opts,
     summary: true
   }
+
   const dependencies = await init(opts)
   const licenses = {}
   const unprocessedLicenseEntries = {}
@@ -165,8 +166,8 @@ export async function getDependencies(opts = {}) {
 }
 
 // Updates existing licenses based on user input and existing dependencies
-export async function getUserLicenseInput(existingLicenses) {
-  const { licenses: licenseMap } = await generateLicensesMap()
+export async function getUserLicenseInput(existingLicenses, licenseInitOpts) {
+  const { licenses: licenseMap } = await generateLicensesMap(licenseInitOpts)
   const approvedLicenses = [...existingLicenses]
   for (const licenseName in licenseMap) {
     if (!existingLicenses.includes(licenseName)) {
@@ -188,8 +189,9 @@ export async function getUserLicenseInput(existingLicenses) {
   return approvedLicenses
 }
 
-export async function getUserModulesInput(existingLicenses, existingModules) {
+export async function getUserModulesInput(existingLicenses, existingModules, licenseInitOpts) {
   const dependencies = await getDependencies({
+    ...licenseInitOpts,
     summary: true
   })
   const unallowedDependencyMap = await getUnallowedDependencies(
@@ -235,12 +237,12 @@ export async function getUserModulesInput(existingLicenses, existingModules) {
 }
 
 // Shows all the licenses in use for each module.
-export async function summary(filePath) {
+export async function summary(filePath, licenseInitOpts) {
   const currentConfig = await getAndValidateConfig(filePath)
   const {
     licenses: licenseMap,
     unprocessedLicenseEntries
-  } = await generateLicensesMap()
+  } = await generateLicensesMap(licenseInitOpts)
   const summary = {
     approved: {},
     unapproved: {},
@@ -345,8 +347,8 @@ export function pruneTreeByLicenses(name, node, invalidLicensedModules) {
 }
 
 // Main method that initiates the checking process
-export async function getInvalidModuleDependencyTree(config) {
-  const licenses = await getDependencies()
+export async function getInvalidModuleDependencyTree(config, licenseInitOpts) {
+  const licenses = await getDependencies(licenseInitOpts)
   const invalidLicensedModules = getInvalidModules(licenses, config)
   if (invalidLicensedModules === undefined) {
     return

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,15 +22,38 @@ program
   .option("--summary", "Prints a summary report")
   .option("-i, --interactive", "Runs in interactive mode.")
   .option(
+    "--environment [environment]",
+    "Which dependencies to check. (production, development, all)",
+    "production"
+  )
+  .option(
     "-m, --modules-only",
     "Modifies module white list if in interactive mode."
   )
 
 // Default Action
 async function action(args: program.Command): Promise<void> {
+  let defaultLicenseInitOpts = {}
+
+  switch (args.environment) {
+    case "development":
+      defaultLicenseInitOpts = {
+        production: undefined,
+        development: true
+      }
+      break
+    case "all":
+      defaultLicenseInitOpts = {
+        production: undefined
+      }
+      break
+    default:
+      break
+  }
+
   const fileName = ".approved-licenses.yml"
   if (args.summary) {
-    const summaryMap = await summary(fileName)
+    const summaryMap = await summary(fileName, defaultLicenseInitOpts)
     const prettySummaryMap = prettySummary(summaryMap)
     console.log(prettySummaryMap)
     if (_.isEmpty(summaryMap.approved)) {
@@ -44,11 +67,15 @@ async function action(args: program.Command): Promise<void> {
   if (args.interactive) {
     const yamlObj = await getAndValidateConfig(fileName)
     if (!args.modulesOnly) {
-      yamlObj.licenses = await getUserLicenseInput(yamlObj.licenses)
+      yamlObj.licenses = await getUserLicenseInput(
+        yamlObj.licenses,
+        defaultLicenseInitOpts
+      )
     }
     yamlObj.modules = await getUserModulesInput(
       yamlObj.licenses,
-      yamlObj.modules
+      yamlObj.modules,
+      defaultLicenseInitOpts
     )
     await writeConfig(fileName, yamlObj)
   }
@@ -70,10 +97,10 @@ async function action(args: program.Command): Promise<void> {
     process.exit(1)
   }
 
-  const depTree = (await getInvalidModuleDependencyTree(parsedConfig)) as any
+  const depTree = (await getInvalidModuleDependencyTree(parsedConfig, defaultLicenseInitOpts)) as any
 
   if (!_.isEmpty(depTree)) {
-    const summaryMap = await summary(fileName)
+    const summaryMap = await summary(fileName, defaultLicenseInitOpts)
     const prettySummaryMap = prettySummary(summaryMap)
     console.log(prettySummaryMap)
     console.log(`UNAPPROVED MODULES:`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ program
   .option("-i, --interactive", "Runs in interactive mode.")
   .option(
     "--environment [environment]",
-    "Which dependencies to check. (production, development, all)",
+    "Which dependencies to check. (production, all)",
     "production"
   )
   .option(
@@ -36,12 +36,6 @@ async function action(args: program.Command): Promise<void> {
   let defaultLicenseInitOpts = {}
 
   switch (args.environment) {
-    case "development":
-      defaultLicenseInitOpts = {
-        production: undefined,
-        development: true
-      }
-      break
     case "all":
       defaultLicenseInitOpts = {
         production: undefined

--- a/test/integ/cli.spec.ts
+++ b/test/integ/cli.spec.ts
@@ -126,6 +126,41 @@ describe("integration test: validates current repo is in a valid state", () => {
     expect(stdout.toString("utf-8")).to.equal(expectedResult)
   }).timeout(20000)
 
+  it("should support fetching all licenses", async () => {
+    const expectedResult = [
+      `Licenses`,
+      "",
+      "APPROVED:",
+      "├─ MIT: 482",
+      "├─ ISC: 81",
+      "├─ BSD-2-Clause: 14",
+      "├─ Apache-2.0: 18",
+      "├─ BSD-3-Clause: 20",
+      "├─ CC-BY-3.0: 1",
+      "├─ CC0-1.0: 1",
+      "├─ (MIT AND CC-BY-3.0): 1",
+      "└─ (MIT OR CC0-1.0): 1",
+      "",
+      "UNAPPROVED:",
+      "├─ (MIT OR Apache-2.0): 1",
+      "├─ BSD: 1",
+      "├─ BSD*: 1",
+      "├─ MIT*: 1",
+      "├─ (WTFPL OR MIT): 1",
+      "├─ Apache License, Version 2.0: 2",
+      "└─ Unlicense: 1",
+      "",
+      "UNPROCESSED:",
+      "└─ json-schema@0.2.3",
+      "   ├─ 0: AFLv2.1",
+      "   └─ 1: BSD",
+      "",
+      ""
+    ].join("\n")
+    let { stdout } = spawnSync("ts-node", ["./src/index.ts", "--summary", "--environment=all"], {})
+    expect(stdout.toString("utf8")).to.equal(expectedResult)
+  }).timeout(20000)
+
   it("should print summary", async () => {
     const expectedResult = [
       `Licenses`,


### PR DESCRIPTION
Add support for not passing the `--production` flag through to the license-checker library.
The default behaviour has not changed, but the command now optionally supports `--environment=all` and `--environment=development` to pass the relevant flags to license-checker.

I went with this flag because if we were to mirror the flags of license-checker it would change the default behaviour.

Open to suggestions for other naming, alternatively we could add a `--no-production` flag.